### PR TITLE
Handle delayed response in is_old_couch

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -28,7 +28,8 @@
 -export([start_delayed_json_response/3, start_delayed_json_response/4,
     start_delayed_chunked_response/3, start_delayed_chunked_response/4,
     send_delayed_chunk/2, send_delayed_last_chunk/1,
-    send_delayed_error/2, end_delayed_json_response/1]).
+    send_delayed_error/2, end_delayed_json_response/1,
+    get_delayed_req/1]).
 
 start_link() ->
     Options = [
@@ -507,6 +508,11 @@ end_delayed_json_response({delayed_resp, StartFun, Req, Code, Headers, FirstChun
     end_delayed_json_response(Resp2);
 end_delayed_json_response(Resp) ->
     end_json_response(Resp).
+
+get_delayed_req({delayed_resp, _, #httpd{mochi_req=MochiReq}, _, _, _}) ->
+    MochiReq;
+get_delayed_req(Resp) ->
+    Resp:get(request).
 
 error_info({Error, Reason}) when is_list(Reason) ->
     error_info({Error, couch_util:to_binary(Reason)});

--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -120,7 +120,7 @@ changes_callback({error, Reason}, {_, Resp}) ->
     chttpd:send_delayed_error(Resp, Reason).
 
 is_old_couch(Resp) ->
-    MochiReq = Resp:get(request),
+    MochiReq = chttpd:get_delayed_req(Resp),
     case MochiReq:get_header_value("user-agent") of
     undefined ->
         false;


### PR DESCRIPTION
is_old_couch expected a mochiweb_response object but would not always
receive one. The delayed response API is expanded to allow access to
the request in all cases (and does not start the response).

BugzID: 12568
