### PR TITLE
encode last seq as well this isn't a string here.

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -109,7 +109,7 @@ changes_callback({stop, EndSeq}, {_, Resp}) ->
         chttpd:send_delayed_chunk(Resp, "\n],\n\"last_seq\":0}\n");
     false ->
         chttpd:send_delayed_chunk(Resp,
-            io_lib:format("\n],\n\"last_seq\":\"~s\"}\n",[EndSeq]))
+            [?JSON_ENCODE({[{<<"last_seq">>, EndSeq}]}) | "\n"])
     end,
     chttpd:end_delayed_json_response(Resp1);
 


### PR DESCRIPTION
last seq isn't encoded which create following error : http://friendpaste.com/43PU6JEPP2lqUQHAIw528t . This patch fix it.
