### PR TITLE
Support custom HTTP/Socket options.

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -106,8 +106,7 @@ start_link(Name, Options) ->
     Options1 = Options ++ [
         {loop, fun ?MODULE:handle_request/1},
         {name, Name},
-        {ip, couch_config:get("chttpd", "bind_address", any)},
-        {backlog, list_to_integer(couch_config:get("chttpd", "backlog", "128"))}
+        {ip, couch_config:get("chttpd", "bind_address", any)}
     ],
     ServerOptsCfg = couch_config:get("chttpd", "server_options", "[]"),
     {ok, ServerOpts} = couch_util:parse_term(ServerOptsCfg),

--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -109,7 +109,10 @@ start_link(Name, Options) ->
         {ip, couch_config:get("chttpd", "bind_address", any)},
         {backlog, list_to_integer(couch_config:get("chttpd", "backlog", "128"))}
     ],
-    case mochiweb_http:start(Options1) of
+    ServerOptsCfg = couch_config:get("chttpd", "server_options", "[]"),
+    {ok, ServerOpts} = couch_util:parse_term(ServerOptsCfg),
+    Options2 = lists:keymerge(1, lists:sort(Options1), lists:sort(ServerOpts)),
+    case mochiweb_http:start(Options2) of
     {ok, Pid} ->
         ok = couch_config:register(fun ?MODULE:config_change/2, Pid),
         {ok, Pid};
@@ -123,6 +126,8 @@ config_change("chttpd", "bind_address") ->
 config_change("chttpd", "port") ->
     ?MODULE:stop();
 config_change("chttpd", "backlog") ->
+    ?MODULE:stop();
+config_change("chttpd", "server_options") ->
     ?MODULE:stop().
 
 stop() ->
@@ -131,6 +136,14 @@ stop() ->
 
 handle_request(MochiReq) ->
     Begin = now(),
+
+    case couch_config:get("chttpd", "socket_options") of
+    undefined ->
+        ok;
+    SocketOptsCfg ->
+        {ok, SocketOpts} = couch_util:parse_term(SocketOptsCfg),
+        ok = mochiweb_socket:setopts(MochiReq:get(socket), SocketOpts)
+    end,
 
     AuthenticationFuns = [
         fun couch_httpd_auth:cookie_authentication_handler/1,


### PR DESCRIPTION
This is a port of COUCHDB-1008 to chttpd. It provides a "server_options"
and "socket_options" variable in the [chttpd] section of the config that
will affect the Mochiweb server and individual connection sockets.

[1] https://github.com/apache/couchdb/commit/ac02c7bdca
[2] https://issues.apache.org/jira/browse/COUCHDB-1008
