### PR TITLE
Fix error handling with delayed responses

### DIFF
--- a/src/chttpd.erl
+++ b/src/chttpd.erl
@@ -583,6 +583,9 @@ send_delayed_chunk(Resp, Chunk) ->
 send_delayed_last_chunk(Req) ->
     send_delayed_chunk(Req, []).
 
+send_delayed_error(#httpd{}=Req, Reason) ->
+    {Code, ErrorStr, ReasonStr} = error_info(Reason),
+    send_error(Req, Code, ErrorStr, ReasonStr);
 send_delayed_error(#delayed_resp{req=Req}, Reason) ->
     {Code, ErrorStr, ReasonStr} = error_info(Reason),
     send_error(Req, Code, ErrorStr, ReasonStr);


### PR DESCRIPTION
If a handler that uses a delayed response encounters an error before it starts the delayed response (ie, calls chttpd:start_delayed_response/1) then it will end up causing an error in chttpd:handle_request/1 when it tries to call Resp:get(code) because at that point Resp is an #httpd{} record.

The easiest fix is to add a clause to chttpd:send_delayed_error to work when it is given an #httpd{} record by calling the normal chttpd:send_error function. This means that client code that uses delayed responses doesn't have to special case errors before and after the call to start_delayed_response.
