### PR TITLE
13133 attachment replication

### DIFF
--- a/src/chttpd_db.erl
+++ b/src/chttpd_db.erl
@@ -782,7 +782,9 @@ update_doc(#httpd{user_ctx=Ctx} = Req, Db, DocId, #doc{deleted=Deleted}=Doc,
     _ ->
         Options = [UpdateType, {user_ctx,Ctx}, {w,W}]
     end,
-    case fabric:update_doc(Db, Doc, Options) of
+    {_, Ref} = spawn_monitor(fun() -> exit(fabric:update_doc(Db, Doc, Options)) end),
+    receive {'DOWN', Ref, _, _, Result} -> ok end,
+    case Result of
     {ok, NewRev} ->
         Accepted = false;
     {accepted, NewRev} ->


### PR DESCRIPTION
calling fabric:update_doc in-process was often swallowing the {Parser, finished} message which causes attachment replication to hang indefinitely.

This PR also includes a fix from couch_http_db to only receive as many bytes as are in the body length.
