### PR TITLE
handle_system_req Memory includes total

### DIFF
--- a/src/chttpd_misc.erl
+++ b/src/chttpd_misc.erl
@@ -262,7 +262,7 @@ handle_system_req(Req) ->
     Other = erlang:memory(system) - lists:sum([X || {_,X} <-
         erlang:memory([atom, code, binary, ets])]),
     Memory = [{other, Other} | erlang:memory([atom, atom_used, processes,
-        processes_used, binary, code, ets])],
+        processes_used, binary, code, ets, total])],
     {NumberOfGCs, WordsReclaimed, _} = statistics(garbage_collection),
     {{input, Input}, {output, Output}} = statistics(io),
     {message_queue_len, MessageQueueLen} = process_info(whereis(couch_server),


### PR DESCRIPTION
I think adding `total` here should fix the issue linked below.

https://cloudant.fogbugz.com/f/cases/47888/DBcore-memory-usage-displayed-in-admin-dashboard-is-wrong
